### PR TITLE
Simplify architecture selection, fix bug in file naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.mod
+cms-master/src/cms
+cms-master/src/getdata

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.o
 *.mod
 cms-master/src/cms

--- a/cms-master/arch/gfortran_compiler
+++ b/cms-master/arch/gfortran_compiler
@@ -7,23 +7,25 @@ FCFLAGS      = -I/usr/include
 #the C-compiler to create object files
 CC            = gcc
 #the C flags to create object files
-CCFLAGS       = -O 
+CCFLAGS       = -O
 
 #the Fortran compiler to create executable
 LD            = $(FC)
 #the Fortran flags to create executable
 LDFLAGS       =  -L/usr/lib -lnetcdf -lnetcdff -lcurl -lm
-EXTRALIBS     = 
+EXTRALIBS     =
 
 # Rules
 
 .c.o:
-	$(CC) -c $*.c $(CCFLAGS) 
+	$(CC) -c $*.c $(CCFLAGS)
 
 .f90.o:
-	$(FC) -c $*.f90 $(FCFLAGS) 
+	$(FC) -c $*.f90 $(FCFLAGS)
 
 .f.o:
-	$(FC) -c $*.f $(FCFLAGS) 
+	$(FC) -c $*.f $(FCFLAGS)
 
+.F90.o:
+	$(FC) -c $*.F90 $(FCFLAGS)
 

--- a/cms-master/arch/gfortran_compiler
+++ b/cms-master/arch/gfortran_compiler
@@ -1,0 +1,29 @@
+# Makefile
+
+#the Fortran compiler to create object files
+FC            = gfortran
+#the Fortran flags to create object files
+FCFLAGS      = -I/usr/include
+#the C-compiler to create object files
+CC            = gcc
+#the C flags to create object files
+CCFLAGS       = -O 
+
+#the Fortran compiler to create executable
+LD            = $(FC)
+#the Fortran flags to create executable
+LDFLAGS       =  -L/usr/lib -lnetcdf -lnetcdff -lcurl -lm
+EXTRALIBS     = 
+
+# Rules
+
+.c.o:
+	$(CC) -c $*.c $(CCFLAGS) 
+
+.f90.o:
+	$(FC) -c $*.f90 $(FCFLAGS) 
+
+.f.o:
+	$(FC) -c $*.f $(FCFLAGS) 
+
+

--- a/cms-master/arch/mpi_compiler
+++ b/cms-master/arch/mpi_compiler
@@ -1,29 +1,32 @@
 # Makefile
 
+
 #the Fortran compiler to create object files
 FC            = mpif90
 #the Fortran flags to create object files
-FCFLAGS      = -I/usr/local/netcdf/include -I/usr/local/include
+FCFLAGS      = -I/usr/local/netcdf/include -I/usr/local/include -I/usr/include -DCMS_MPI
 #the C-compiler to create object files
 CC            = gcc
 #the C flags to create object files
-CCFLAGS       = -O 
+CCFLAGS       = -O
 
 #the Fortran compiler to create executable
 LD            = $(FC)
 #the Fortran flags to create executable
 LDFLAGS       = -L/usr/local/netcdf/lib -L/usr/local/lib -lnetcdf -lnetcdff -lcurl -lm
-EXTRALIBS     = 
+EXTRALIBS     =
 
 # Rules
 
 .c.o:
-	$(CC) -c $*.c $(CCFLAGS) 
+	$(CC) -c $*.c $(CCFLAGS)
 
 .f90.o:
-	$(FC) -c $*.f90 $(FCFLAGS) 
+	$(FC) -c $*.f90 $(FCFLAGS)
 
 .f.o:
-	$(FC) -c $*.f $(FCFLAGS) 
+	$(FC) -c $*.f $(FCFLAGS)
 
+.F90.o:
+	$(FC) -c $*.F90 $(FCFLAGS)
 

--- a/cms-master/src/Makefile
+++ b/cms-master/src/Makefile
@@ -1,6 +1,6 @@
 #
 
-include ../arch/mpi_compiler
+include ../arch/gfortran_compiler
 
 .SUFFIXES: 
 .SUFFIXES: .cpp .c .F .f .o .f90

--- a/cms-master/src/Makefile
+++ b/cms-master/src/Makefile
@@ -1,15 +1,18 @@
 #
 
-include ../arch/gfortran_compiler
+#include ../arch/gfortran_compiler
+include ../arch/mpi_compiler
 
-.SUFFIXES: 
-.SUFFIXES: .cpp .c .F .f .o .f90
+.SUFFIXES:
+.SUFFIXES: .cpp .c .F .f .o .f90 .F90
 
 .F:
 	@echo "Must have an explicit rule for" $*
 .f:
 	@echo "Must have an explicit rule for" $*
 .f90:
+	@echo "Must have an explicit rule for" $*
+.F90:
 	@echo "Must have an explicit rule for" $*
 .c:
 	@echo "Must have an explicit rule for" $*
@@ -21,22 +24,22 @@ MODS =  mod_kinds.o def_constants.o def_nests.o def_particle.o def_globalvariabl
         mod_turb.o mod_strata.o mod_reef.o mod_diffpart.o mod_directory.o mod_mixedlayerphysics.o
 
 OBJS =  input.o output.o restart.o util.o loop.o rungekutta.o findnest.o move.o updateloc.o \
-        getphysicaldata.o getfilename.o getnestinfo.o lonlat2ij.o fldinterp.o dealloc.o cms.o 
+        getphysicaldata.o getfilename.o getnestinfo.o lonlat2ij.o fldinterp.o dealloc.o cms.o
 
-MODS_getdata = mod_kinds.o mod_netcdf.o mod_iounits.o mod_nciorw.o mod_calendar.o mod_directory.o mod_getdata.o 
-        
-OBJS_getdata =  util.o getdata.o 
+MODS_getdata = mod_kinds.o mod_netcdf.o mod_iounits.o mod_nciorw.o mod_calendar.o mod_directory.o mod_getdata.o
+
+OBJS_getdata =  util.o getdata.o
 
 MODS_larva = $(MODS) mod_buoyancy_larva.o mod_mort_larva.o
 OBJS_larva = $(OBJS)
 
 cms	:	$(MODS_larva) $(OBJS_larva)
-	        $(LD) $(MODS_larva) $(OBJS_larva) $(LDFLAGS) -o cms $(EXTRALIBS)	        	       
-	  
+	        $(LD) $(MODS_larva) $(OBJS_larva) $(LDFLAGS) -o cms $(EXTRALIBS)
+
 getdata :	$(MODS_getdata) $(OBJS_getdata)
-		$(LD) $(MODS_getdata) $(OBJS_getdata)  $(LDFLAGS) -o getdata $(EXTRALIBS)	        
-	        
-cms.o: cms.f90
+		$(LD) $(MODS_getdata) $(OBJS_getdata)  $(LDFLAGS) -o getdata $(EXTRALIBS)
+
+cms.o: cms.F90
 getdata.o: getdata.f90
 
 def_nests.o: def_nests.f90
@@ -69,7 +72,7 @@ mod_turb.o: mod_turb.f90
 mod_mort_oil.o: mod_mort_oil.f90
 mod_mort_larva.o: mod_mort_larva.f90
 mod_buoyancy_larva.o: mod_buoyancy_larva.f90
-mod_buoyancy_oil.o: mod_buoyancy_oil.f90 
+mod_buoyancy_oil.o: mod_buoyancy_oil.f90
 mod_reef.o: mod_reef.f90
 mod_calendar.o: mod_calendar.f90
 mod_kinds.o: mod_kinds.f90
@@ -81,5 +84,5 @@ mod_mixedlayerphysics.o: mod_mixedlayerphysics.f90
 mod_getdata.o: mod_getdata.f90
 
 .PHONY: clean
-clean:   
-	rm *.mod *.o cms getdata
+clean:
+	rm -f *.mod *.o cms getdata

--- a/cms-master/src/cms.F90
+++ b/cms-master/src/cms.F90
@@ -2,7 +2,7 @@
 !* System: Connectivity Modeling System (CMS)                               *
 !* File : cms.f90                                                           *
 !* Last Modified: 2016-09-07                                                *
-!* Code contributors: Claire B. Paris, Ana Carolina Vaz, Judith Helgers,    * 
+!* Code contributors: Claire B. Paris, Ana Carolina Vaz, Judith Helgers,    *
 !*                    Ashwanth Srinivasan                                   *
 !*                                                                          *
 !* Copyright (C) 2011, University of Miami                                  *
@@ -24,14 +24,16 @@
 
 PROGRAM CMS
 
-! USE MPI !remove if not using mpi
+#ifdef CMS_MPI
+ USE MPI !remove if not using mpi
+#endif
  USE globalvariables
  USE mod_random
- 
+
  IMPLICIT NONE
 
  EXTERNAL directory
- 
+
  character(char_len)     :: filenumber
  integer (kind=int_kind) :: ierr, my_id, npes, number1, number2
  logical (kind=log_kind) :: file_exists
@@ -40,11 +42,13 @@ PROGRAM CMS
  npes = 1 !used if not using mpi
 
 !initialise MPI
-! CALL MPI_INIT(ierr) !remove if not using mpi
+#ifdef CMS_MPI
+ CALL MPI_INIT(ierr) !remove if not using mpi
 !what processor am I (what is my rank)?
-! CALL MPI_COMM_RANK(MPI_COMM_WORLD, my_id, ierr) !remove if not using mpi
+ CALL MPI_COMM_RANK(MPI_COMM_WORLD, my_id, ierr) !remove if not using mpi
 !how many processors are there?
-! CALL MPI_COMM_SIZE(MPI_COMM_WORLD, npes, ierr) !remove if not using mpi
+ CALL MPI_COMM_SIZE(MPI_COMM_WORLD, npes, ierr) !remove if not using mpi
+#endif
 
 !check which experiment to run
  IF (command_argument_count() .eq. 0) THEN
@@ -59,8 +63,8 @@ PROGRAM CMS
  number1 = abs(mod((number1*(my_id+1)),31328))
  number2 = abs(mod((number2*(my_id+1)),30081))
  CALL random_initialize (number1,number2)
- 
-!check whether input runconf file exists 
+
+!check whether input runconf file exists
  write(fileinput,'(A,A,A)') 'input_',trim(filenumber), '/'
  INQUIRE(FILE=trim(fileinput)//'runconf.list',EXIST=file_exists)
  IF (file_exists .eqv. .false.) THEN
@@ -88,9 +92,11 @@ PROGRAM CMS
  CALL loop(my_id, npes)
 
 !finish up
- CALL dealloc_all 
+ CALL dealloc_all
 
 !quit MPI
- !CALL MPI_FINALIZE(ierr) !remove if not using mpi
-     
+#ifdef CMS_MPI
+ CALL MPI_FINALIZE(ierr) !remove if not using mpi
+#endif
+
 END PROGRAM CMS

--- a/cms-master/src/cms.f90
+++ b/cms-master/src/cms.f90
@@ -24,7 +24,7 @@
 
 PROGRAM CMS
 
- USE MPI !remove if not using mpi
+! USE MPI !remove if not using mpi
  USE globalvariables
  USE mod_random
  
@@ -40,11 +40,11 @@ PROGRAM CMS
  npes = 1 !used if not using mpi
 
 !initialise MPI
- CALL MPI_INIT(ierr) !remove if not using mpi
+! CALL MPI_INIT(ierr) !remove if not using mpi
 !what processor am I (what is my rank)?
- CALL MPI_COMM_RANK(MPI_COMM_WORLD, my_id, ierr) !remove if not using mpi
+! CALL MPI_COMM_RANK(MPI_COMM_WORLD, my_id, ierr) !remove if not using mpi
 !how many processors are there?
- CALL MPI_COMM_SIZE(MPI_COMM_WORLD, npes, ierr) !remove if not using mpi
+! CALL MPI_COMM_SIZE(MPI_COMM_WORLD, npes, ierr) !remove if not using mpi
 
 !check which experiment to run
  IF (command_argument_count() .eq. 0) THEN
@@ -91,6 +91,6 @@ PROGRAM CMS
  CALL dealloc_all 
 
 !quit MPI
- CALL MPI_FINALIZE(ierr) !remove if not using mpi
+ !CALL MPI_FINALIZE(ierr) !remove if not using mpi
      
 END PROGRAM CMS

--- a/cms-master/src/mod_directory.c
+++ b/cms-master/src/mod_directory.c
@@ -2,7 +2,7 @@
 //* System: Connectivity Modeling System (CMS)                               *
 //* File : directory.c                                                       *
 //* Last Modified: 2011-07-22                                                *
-//* Code contributors: Judith Helgers, Ashwanth Srinivasan, Claire B. Paris  * 
+//* Code contributors: Judith Helgers, Ashwanth Srinivasan, Claire B. Paris  *
 //*                                                                          *
 //* Copyright (C) 2011, University of Miami                                  *
 //*                                                                          *
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "mod_directory.h"
 
@@ -44,22 +45,25 @@ void make_dir_(char * filename, int * len_file)
       unlink(file);
       exit(1);
       }
-} 
+}
 
 //copy files from directory dir1 to dir2
 void rename_file_ (char * dir1, char * dir2, int * len_dir1, int * len_dir2)
 {
    int status, errno;
-   char dirOld[*len_dir1];
-   char dirNew[*len_dir2];
+   char dirOld[*len_dir1 + 1];
+   char dirNew[*len_dir2 + 1];
+
+   // printf("In rename_file: %s  %s  %d %d\n", dir1, dir2, *len_dir1, *len_dir2);
 
    substr(dirOld, dir1, 0, *len_dir1);
-   substr(dirNew, dir2, 0, *len_dir2); 
+   substr(dirNew, dir2, 0, *len_dir2);
 
+   // printf("dirOld, dirNew: %s %s\n", dirOld, dirNew);
    status = remove(dirNew);
    status = rename(dirOld, dirNew);
 
-   if (status == -1) 
+   if (status == -1)
    {
     perror("rename Error");
     exit(1);
@@ -67,11 +71,11 @@ void rename_file_ (char * dir1, char * dir2, int * len_dir1, int * len_dir2)
 }
 
 
-substr(char dest[], char src[], int offset, int len)
+void substr(char dest[], char src[], int offset, int len)
 {
   int i;
   for(i = 0; i < len && src[offset + i] != '\0'; i++)
-	dest[i] = src[i + offset];
+        dest[i] = src[i + offset];
   dest[i] = '\0';
 }
 

--- a/cms-master/src/mod_directory.h
+++ b/cms-master/src/mod_directory.h
@@ -1,3 +1,4 @@
+void substr(char dest[], char src[], int offset, int len);
 void make_dir_(char * filename, int * len_file);
 void rename_file_ (char * dir1, char * dir2, int * len_dir1, int * len_dir2);
 


### PR DESCRIPTION
This PR does the following:
- Adds a .gitignore file.
- Fixes a memory-overwriting bug in the file-renaming code.
- Adds a generic single-processor gfortran architecture.
- Localizes the selection of the architecture to a single line in Makefile, so nothing else needs to be edited.

Ideally this PR would be split up and reorganized, but that would take time I would rather not devote to it, given that I think all parts of the PR should be merged. 

The memory-overwrite bug in mod_directory.c was sometimes preventing the output files from being moved between "SCRATCH" and "output".

Some of the commits look more extensive than they actually are because I use an editor that strips trailing whitespace.  Ideally, all trailing whitespace would already have been stripped. 